### PR TITLE
Fix memory allocation size in constructor

### DIFF
--- a/world.cpp
+++ b/world.cpp
@@ -2,7 +2,7 @@
 #include <cstring>
 
 World::World( int x, int y ) : m_Width( x ), m_Height( y ) {
-        int s = m_Width * m_Height * sizeof( byte );
+        int s = m_Width * m_Height;
         p_Cells = new byte[s];
         memset( p_Cells, 0, s );
     }


### PR DESCRIPTION
Количество байт памяти, выделяемой под массив ячеек, не должно умножаться на sizeof(byte), как я понимаю.